### PR TITLE
fix(scroll): small json injection vulnerability

### DIFF
--- a/scroll.go
+++ b/scroll.go
@@ -47,7 +47,16 @@ func (d *dumper) scrollSlice(ctx context.Context, index string, sliceIdx, sliceT
 	var newScrollID string
 	for {
 		reqStart := time.Now()
-		q = fmt.Sprintf(`{"scroll": "%s", "scroll_id": "%s"}`, d.scrollTimeoutES, scrollID)
+		scrollReq := map[string]string{
+			"scroll":    d.scrollTimeoutES,
+			"scroll_id": scrollID,
+		}
+		qBytes, err := json.Marshal(scrollReq)
+		if err != nil {
+			d.clearScrollContext(scrollID)
+			return fmt.Errorf("marshaling scroll request: %w", err)
+		}
+		q = string(qBytes)
 		newScrollID, _, more, err = d.scrollRequest(ctx, "_search/scroll", q)
 		if err != nil || !more {
 			break


### PR DESCRIPTION
Fix JSON injection vulnerability in scroll request

## Security Fix

This PR fixes a JSON injection vulnerability in the scroll request handling code.

### Issue

The scroll request was constructed using `fmt.Sprintf` which directly interpolated the `scrollID` value from Elasticsearch responses into a JSON string without proper escaping:

```go
q = fmt.Sprintf(`{"scroll": "%s", "scroll_id": "%s"}`, d.scrollTimeoutES, scrollID)
```

If a malicious or compromised Elasticsearch server returned a `scrollID` containing special JSON characters (like quotes, backslashes, or newlines), it could:
- Break JSON parsing
- Potentially enable JSON injection attacks
- Cause the application to fail unexpectedly

### Solution

Replaced string formatting with proper JSON marshaling using `json.Marshal`, which automatically escapes all special characters:

```go
scrollReq := map[string]string{
    "scroll":    d.scrollTimeoutES,
    "scroll_id": scrollID,
}
qBytes, err := json.Marshal(scrollReq)
if err != nil {
    d.clearScrollContext(scrollID)
    return fmt.Errorf("marshaling scroll request: %w", err)
}
q = string(qBytes)
```

### Changes

- Replace `fmt.Sprintf` with `json.Marshal` for constructing scroll request JSON
- Add proper error handling with scroll context cleanup on marshaling failure
- Maintain backward compatibility - no functional changes to API or behavior

### Security Impact

**Severity:** Medium  
**Type:** JSON Injection / Input Validation  
**Affected:** All versions using scroll API

This fix ensures that scroll IDs are properly escaped when constructing JSON requests, preventing potential injection attacks even when interacting with untrusted or compromised Elasticsearch servers.
